### PR TITLE
Integrate Options in SchemaObject

### DIFF
--- a/test-d/schema.ts
+++ b/test-d/schema.ts
@@ -24,7 +24,7 @@ const foo = {
 };
 
 type FooOption = 'A' | 'B';
-type FooSchema = Schema<typeof foo, FooOption, {recurseIntoArrays: false}>;
+type FooSchema = Schema<typeof foo, FooOption>;
 
 const fooSchema: FooSchema = {
 	baz: 'A',
@@ -126,3 +126,77 @@ expectType<ComplexOption>(complexBarSchema.readonlySet);
 expectType<readonly ComplexOption[]>(complexBarSchema.readonlyArray);
 expectType<readonly [ComplexOption]>(complexBarSchema.readonlyTuple);
 expectType<ComplexOption>(complexBarSchema.regExp);
+
+// With Options and `recurseIntoArrays` set to `false`
+type FooSchemaWithOptionsNoRecurse = Schema<typeof foo, FooOption, {recurseIntoArrays: false}>;
+
+const fooSchemaWithOptionsNoRecurse: FooSchemaWithOptionsNoRecurse = {
+	baz: 'A',
+	bar: {
+		function: 'A',
+		object: {key: 'A'},
+		string: 'A',
+		number: 'A',
+		boolean: 'A',
+		symbol: 'A',
+		map: 'A',
+		set: 'A',
+		array: 'A',
+		tuple: 'A',
+		objectArray: 'A',
+		readonlyMap: 'A',
+		readonlySet: 'A',
+		readonlyArray: 'A' as const,
+		readonlyTuple: 'A' as const,
+		regExp: 'A',
+	},
+};
+
+expectNotAssignable<FooSchemaWithOptionsNoRecurse>(foo);
+expectNotAssignable<FooSchemaWithOptionsNoRecurse>({key: 'value'});
+expectNotAssignable<FooSchemaWithOptionsNoRecurse>(new Date());
+expectType<FooOption>(fooSchemaWithOptionsNoRecurse.baz);
+
+const barSchemaWithOptionsNoRecurse = fooSchemaWithOptionsNoRecurse.bar as Schema<typeof foo['bar'], FooOption, {recurseIntoArrays: false}>;
+expectType<FooOption>(barSchemaWithOptionsNoRecurse.function);
+expectType<FooOption | {key: FooOption}>(barSchemaWithOptionsNoRecurse.object);
+expectType<FooOption>(barSchemaWithOptionsNoRecurse.string);
+expectType<FooOption>(barSchemaWithOptionsNoRecurse.number);
+expectType<FooOption>(barSchemaWithOptionsNoRecurse.boolean);
+expectType<FooOption>(barSchemaWithOptionsNoRecurse.symbol);
+expectType<FooOption>(barSchemaWithOptionsNoRecurse.map);
+expectType<FooOption>(barSchemaWithOptionsNoRecurse.set);
+expectType<FooOption>(barSchemaWithOptionsNoRecurse.array);
+expectType<FooOption>(barSchemaWithOptionsNoRecurse.tuple);
+expectType<FooOption>(barSchemaWithOptionsNoRecurse.objectArray);
+expectType<FooOption>(barSchemaWithOptionsNoRecurse.readonlyMap);
+expectType<FooOption>(barSchemaWithOptionsNoRecurse.readonlySet);
+expectType<FooOption>(barSchemaWithOptionsNoRecurse.readonlyArray);
+expectType<FooOption>(barSchemaWithOptionsNoRecurse.readonlyTuple);
+expectType<FooOption>(barSchemaWithOptionsNoRecurse.regExp);
+
+// With Options and `recurseIntoArrays` set to `true`
+type FooSchemaWithOptionsRecurse = Schema<typeof foo, FooOption, {recurseIntoArrays: true}>;
+
+expectNotAssignable<FooSchemaWithOptionsRecurse>(foo);
+expectNotAssignable<FooSchemaWithOptionsRecurse>({key: 'value'});
+expectNotAssignable<FooSchemaWithOptionsRecurse>(new Date());
+expectType<FooOption>(fooSchema.baz);
+
+const barSchemaWithOptionsRecurse = fooSchema.bar as Schema<typeof foo['bar'], FooOption>;
+expectType<FooOption>(barSchemaWithOptionsRecurse.function);
+expectType<FooOption | {key: FooOption}>(barSchemaWithOptionsRecurse.object);
+expectType<FooOption>(barSchemaWithOptionsRecurse.string);
+expectType<FooOption>(barSchemaWithOptionsRecurse.number);
+expectType<FooOption>(barSchemaWithOptionsRecurse.boolean);
+expectType<FooOption>(barSchemaWithOptionsRecurse.symbol);
+expectType<FooOption>(barSchemaWithOptionsRecurse.map);
+expectType<FooOption>(barSchemaWithOptionsRecurse.set);
+expectType<FooOption[]>(barSchemaWithOptionsRecurse.array);
+expectType<FooOption[]>(barSchemaWithOptionsRecurse.tuple);
+expectType<Array<{key: FooOption}>>(barSchemaWithOptionsRecurse.objectArray);
+expectType<FooOption>(barSchemaWithOptionsRecurse.readonlyMap);
+expectType<FooOption>(barSchemaWithOptionsRecurse.readonlySet);
+expectType<readonly FooOption[]>(barSchemaWithOptionsRecurse.readonlyArray);
+expectType<readonly [FooOption]>(barSchemaWithOptionsRecurse.readonlyTuple);
+expectType<FooOption>(barSchemaWithOptionsRecurse.regExp);


### PR DESCRIPTION
- Added required check for Options in `SchemaObject`
- Added tests
- Updated usage examples